### PR TITLE
feat(프로필) : 프로필 계정별 정보 불러오기 / 팔로우 기능 구현

### DIFF
--- a/src/apis/profile/accountInfoAPI.js
+++ b/src/apis/profile/accountInfoAPI.js
@@ -1,0 +1,6 @@
+import { api } from '../baseURL';
+
+export const readAccountInfo = async (accountname) => {
+  const { data } = await api.get('/profile/' + accountname);
+  return data;
+};

--- a/src/apis/profile/followAPI.js
+++ b/src/apis/profile/followAPI.js
@@ -1,0 +1,6 @@
+import { api } from '../baseURL';
+
+export const followUser = async (accountname) => {
+  const { data } = await api.post('/profile/' + accountname + '/follow');
+  return data;
+};

--- a/src/apis/profile/followersAPI.js
+++ b/src/apis/profile/followersAPI.js
@@ -1,0 +1,6 @@
+import { api } from '../baseURL';
+
+export const readFollowers = async (accountname) => {
+  const { data } = await api.get('/profile/' + accountname + '/follower');
+  return data;
+};

--- a/src/apis/profile/followingsAPI.js
+++ b/src/apis/profile/followingsAPI.js
@@ -1,0 +1,6 @@
+import { api } from '../baseURL';
+
+export const readFollowings = async (accountname) => {
+  const { data } = await api.get('/profile/' + accountname + '/following');
+  return data;
+};

--- a/src/apis/profile/myInfoAPI.js
+++ b/src/apis/profile/myInfoAPI.js
@@ -1,7 +1,6 @@
 import { api } from '../baseURL';
 
-// 로그인
 export const readUserInfo = async () => {
-  const { data } = await api.get('/user/myinfo');
+  const { data } = await api.get('/user/myinfo', { timeout: 10000 });
   return data;
 };

--- a/src/apis/profile/unfollowAPI.js
+++ b/src/apis/profile/unfollowAPI.js
@@ -1,0 +1,6 @@
+import { api } from '../baseURL';
+
+export const unfollowUser = async (accountname) => {
+  const { data } = await api.delete('/profile/' + accountname + '/unfollow');
+  return data;
+};

--- a/src/components/common/NavBar/NavBar.jsx
+++ b/src/components/common/NavBar/NavBar.jsx
@@ -9,8 +9,6 @@ export default function Header() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
 
-  console.log(pathname);
-
   const handleSearchClick = () => {
     navigate('/home/search');
   };
@@ -35,19 +33,19 @@ export default function Header() {
           <S.SaveBtn>업로드</S.SaveBtn>
         </>
       )}
-      {pathname === '/profile' && (
+      {pathname.includes('profile') && !pathname.includes('follow') && (
         <>
           <S.ArrowLeftImg src={arrowLeft} onClick={() => navigate(-1)} />
           <S.KebabBtnImg src={KebabBtn} />
         </>
       )}
-      {pathname === '/followers' && (
+      {pathname.includes('follower') && (
         <>
           <S.ArrowLeftImg src={arrowLeft} onClick={() => navigate(-1)} />
           <S.HeaderContent>Followers</S.HeaderContent>
         </>
       )}
-      {pathname === '/followings' && (
+      {pathname.includes('following') && (
         <>
           <S.ArrowLeftImg src={arrowLeft} onClick={() => navigate(-1)} />
           <S.HeaderContent>Followings</S.HeaderContent>

--- a/src/components/follow/FollowList.jsx
+++ b/src/components/follow/FollowList.jsx
@@ -1,27 +1,51 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import * as S from './FollowList.styled';
 import { useNavigate } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
+import { followUser } from '../../apis/profile/followAPI';
+import { unfollowUser } from '../../apis/profile/unfollowAPI';
 import basicProfile from '../../assets/images/profile/basic-profile-img.svg';
 
-export default function PostFollowers() {
-  const [flag, setFlag] = useState(false);
+export default function FollowList({ data }) {
+  const [follow, setFollow] = useState(data.isfollow);
   const navigate = useNavigate();
+
+  const followMutation = useMutation({
+    mutationFn: followUser,
+    onSuccess: (res) => {
+      setFollow(true);
+    },
+    onError: (err) => {}
+  });
+  const unfollowMutation = useMutation({
+    mutationFn: unfollowUser,
+    onSuccess: (res) => {
+      setFollow(false);
+    },
+    onError: (err) => {}
+  });
+
+  useEffect(() => {
+    setFollow(data.isfollow);
+  }, [data.isfollow]);
 
   return (
     <S.ProfileFollowersLayout>
       <S.FollowerRowBox>
         <S.FollowerBox>
-          <S.FollowerImgBox onClick={() => navigate('/profile')}>
-            <img src={basicProfile} alt='' />
+          <S.FollowerImgBox onClick={() => navigate('/profile/' + data.accountname)}>
+            <img src={String(data.image).includes('Ellipse.png') ? basicProfile : data.image} alt='' />
           </S.FollowerImgBox>
-          <S.FollowerTextBox onClick={() => navigate('/profile')}>
-            <S.FollowerTitleContent>애월읍 한라봉 최고 맛집</S.FollowerTitleContent>
-            <S.FollowerIntroContent>정성을 다해 농사짓는 한라봉</S.FollowerIntroContent>
+          <S.FollowerTextBox onClick={() => navigate('/profile/' + data.accountname)}>
+            <S.FollowerTitleContent>{data.username}</S.FollowerTitleContent>
+            <S.FollowerIntroContent>{data.intro}</S.FollowerIntroContent>
           </S.FollowerTextBox>
-          {flag ? (
-            <S.FollowerButton onClick={() => setFlag(!flag)}>팔로우</S.FollowerButton>
+          {!follow ? (
+            <S.FollowerButton onClick={() => followMutation.mutate(data.accountname)}>팔로우</S.FollowerButton>
           ) : (
-            <S.FollowerPauseButton onClick={() => setFlag(!flag)}>취소</S.FollowerPauseButton>
+            <S.FollowerPauseButton onClick={() => unfollowMutation.mutate(data.accountname)}>
+              취소
+            </S.FollowerPauseButton>
           )}
         </S.FollowerBox>
       </S.FollowerRowBox>

--- a/src/components/follow/FollowList.styled.js
+++ b/src/components/follow/FollowList.styled.js
@@ -1,14 +1,8 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
 const mainColor = `#f26e22`;
 
-const common = css`
-  line-height: normal;
-  box-sizing: border-box;
-`;
-
 export const ProfileFollowersLayout = styled.div`
-  ${common}
   width: 100vw;
   background: #fff;
 
@@ -17,31 +11,8 @@ export const ProfileFollowersLayout = styled.div`
   flex-direction: column;
 `;
 
-export const ProfileHeaderLayout = styled.div`
-  width: 100vw;
-  display: flex;
-  align-items: center;
-  height: 48px;
-
-  border-bottom: 0.5px solid #dbdbdb;
-  background-color: #fff;
-`;
-
-export const NavButton = styled.button`
-  border: none;
-  background-color: #fff;
-  width: fit-content;
-  height: fit-content;
-  padding: 3px 0 0 16px;
-`;
-
-export const NavContent = styled.p`
-  font-size: 14px;
-  margin-left: 8px;
-`;
-
 export const FollowerRowBox = styled.div`
-  padding: 24px 16px;
+  padding: 0 16px;
 
   display: flex;
   flex-direction: column;

--- a/src/components/profile/ProfileInfo/ProfileInfo.jsx
+++ b/src/components/profile/ProfileInfo/ProfileInfo.jsx
@@ -4,38 +4,41 @@ import * as S from './ProfileInfo.styled';
 import basicProfile from '../../../assets/images/profile/basic-profile-img.svg';
 import ProfileInfoBtn from './ProfileInfoBtn';
 import ProfileMyInfoBtn from './ProfileInfoMyBtn';
+import { atom, useRecoilState, useRecoilValue } from 'recoil';
+import { atomMyInfo } from '../../../store/store';
 
-export default function ProfileInfo() {
-  const user_flag = true;
+export default function ProfileInfo({ profile }) {
+  const user = useRecoilValue(atomMyInfo);
+  const user_flag = user.accountname === profile.accountname;
   const navigate = useNavigate();
 
   const handleFollowClick = (url) => {
-    navigate('/' + url);
+    navigate('/profile/' + profile.accountname + url);
   };
 
   return (
     <S.ProfileInfoLayout>
       <S.RowBox>
         <S.ColBox>
-          <S.FollowNum onClick={() => handleFollowClick('followers')} $fontColor='#000'>
-            2950
+          <S.FollowNum onClick={() => handleFollowClick('/follower')} $fontColor='#000'>
+            {profile.followerCount}
           </S.FollowNum>
           <S.FollowText>followers</S.FollowText>
         </S.ColBox>
         <S.ImgBox>
-          <img src={basicProfile} alt='회원 프로필 사진'></img>
+          <img src={String(profile.image).includes('Ellipse.png') ? basicProfile : profile.image} alt=''></img>
         </S.ImgBox>
         <S.ColBox>
-          <S.FollowNum onClick={() => handleFollowClick('followings')} $fontColor='#767676'>
-            128
+          <S.FollowNum onClick={() => handleFollowClick('/following')} $fontColor='#767676'>
+            {profile.followingCount}
           </S.FollowNum>
           <S.FollowText>followings</S.FollowText>
         </S.ColBox>
       </S.RowBox>
-      <S.TitleContent>애월읍 위니브 감귤농장</S.TitleContent>
-      <S.IDContent>@ weniv_Mandarin</S.IDContent>
-      <S.IntroContent>애월읍 감귤 전국 배송, 귤따기 체험, 감귤 농장</S.IntroContent>
-      <S.RowButtonBox>{user_flag ? <ProfileMyInfoBtn /> : <ProfileInfoBtn />}</S.RowButtonBox>
+      <S.TitleContent>{profile.username}</S.TitleContent>
+      <S.IDContent>{'@' + profile.accountname}</S.IDContent>
+      <S.IntroContent>{profile.intro}</S.IntroContent>
+      <S.RowButtonBox>{user_flag ? <ProfileMyInfoBtn /> : <ProfileInfoBtn profile={profile} />}</S.RowButtonBox>
     </S.ProfileInfoLayout>
   );
 }

--- a/src/components/profile/ProfileInfo/ProfileInfo.styled.js
+++ b/src/components/profile/ProfileInfo/ProfileInfo.styled.js
@@ -4,7 +4,6 @@ const mainColor = `#f26e22`;
 
 export const ProfileInfoLayout = styled.div`
   width: 100vw;
-  height: 314px;
   display: flex;
   align-items: center;
   flex-direction: column;
@@ -13,6 +12,8 @@ export const ProfileInfoLayout = styled.div`
   border: 0.5px solid #dbdbdb;
   border-left: none;
   border-right: none;
+  padding-top: 78px;
+  padding-bottom: 26px;
 `;
 
 export const RowBox = styled.div`
@@ -31,6 +32,15 @@ export const ImgBox = styled.div`
   height: 110px;
   border-radius: 50%;
   margin: 0 40px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #dbdbdb;
+  & img {
+    min-width: 110px;
+    min-height: 110px;
+  }
 `;
 
 export const FollowText = styled.p`

--- a/src/components/profile/ProfileInfo/ProfileInfoBtn.jsx
+++ b/src/components/profile/ProfileInfo/ProfileInfoBtn.jsx
@@ -1,22 +1,50 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import * as S from './ProfileInfo.styled';
+import { followUser } from '../../../apis/profile/followAPI';
+import { unfollowUser } from '../../../apis/profile/unfollowAPI';
+import { useMutation, useQuery } from '@tanstack/react-query';
 
-export default function ProfileInfoBtn() {
-  const [follow, setFollow] = useState(true);
+export default function ProfileInfoBtn({ profile }) {
+  const [follow, setFollow] = useState(profile.isfollow);
+
+  useEffect(() => {
+    setFollow(profile.isfollow);
+  }, [profile.isfollow]);
+
+  const followMutation = useMutation({
+    mutationFn: followUser,
+    onSuccess: (res) => {
+      setFollow(!follow);
+    },
+    onError: (err) => {}
+  });
+  const unfollowMutation = useMutation({
+    mutationFn: unfollowUser,
+    onSuccess: (res) => {
+      setFollow(!follow);
+    },
+    onError: (err) => {}
+  });
 
   return (
     <>
-      {/* <S.IconButton></S.IconButton> */}
-      {follow ? (
-        <S.FollowButton $follow='true' onClick={() => setFollow(!follow)}>
+      {!follow ? (
+        <S.FollowButton
+          $follow='true'
+          onClick={() => {
+            followMutation.mutate(profile.accountname);
+          }}>
           팔로우
         </S.FollowButton>
       ) : (
-        <S.FollowButton $follow='' onClick={() => setFollow(!follow)}>
+        <S.FollowButton
+          $follow=''
+          onClick={() => {
+            unfollowMutation.mutate(profile.accountname);
+          }}>
           언팔로우
         </S.FollowButton>
       )}
-      {/* <S.IconButton></S.IconButton> */}
     </>
   );
 }

--- a/src/pages/followers/Followers.jsx
+++ b/src/pages/followers/Followers.jsx
@@ -1,18 +1,37 @@
-import React from 'react';
+import React, { useState } from 'react';
 import NavBar from '../../components/common/NavBar/NavBar';
 import FollowList from '../../components/follow/FollowList';
 import styled from 'styled-components';
+import { useQuery } from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
+import { readFollowers } from '../../apis/profile/followersAPI';
 
 const ContBox = styled.div`
+  width: 100vw;
   height: 100vh;
   background-color: #fff;
+  padding-top: 72px;
 `;
 
 export default function Followers() {
+  const [followers, setFollowers] = useState([]);
+  const { accountname } = useParams();
+  const { data, err } = useQuery({
+    queryFn: () =>
+      readFollowers(accountname).then((res) => {
+        setFollowers(res);
+        return res;
+      }),
+    queryKey: ['followers']
+  });
   return (
-    <ContBox>
+    <>
       <NavBar />
-      <FollowList />
-    </ContBox>
+      <ContBox>
+        {followers.map((v, i) => (
+          <FollowList key={i} data={v} />
+        ))}
+      </ContBox>
+    </>
   );
 }

--- a/src/pages/followings/Followings.jsx
+++ b/src/pages/followings/Followings.jsx
@@ -1,18 +1,37 @@
-import React from 'react';
+import React, { useState } from 'react';
 import NavBar from '../../components/common/NavBar/NavBar';
 import FollowList from '../../components/follow/FollowList';
 import styled from 'styled-components';
+import { useQuery } from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
+import { readFollowings } from '../../apis/profile/followingsAPI';
 
 const ContBox = styled.div`
+  width: 100vw;
   height: 100vh;
   background-color: #fff;
+  padding-top: 72px;
 `;
 
 export default function Followings() {
+  const [followings, setFollowings] = useState([]);
+  const { accountname } = useParams();
+  const { data, err } = useQuery({
+    queryFn: () =>
+      readFollowings(accountname).then((res) => {
+        setFollowings(res);
+        return res;
+      }),
+    queryKey: ['followings']
+  });
   return (
-    <ContBox>
+    <>
       <NavBar />
-      <FollowList />
-    </ContBox>
+      <ContBox>
+        {followings.map((v, i) => (
+          <FollowList key={i} data={v} />
+        ))}
+      </ContBox>
+    </>
   );
 }

--- a/src/pages/profile/Profile.jsx
+++ b/src/pages/profile/Profile.jsx
@@ -1,11 +1,14 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import NavBar from '../../components/common/NavBar/NavBar';
 import TabMenu from '../../components/common/TabMenu/TabMenu';
 import ProfileInfo from '../../components/profile/ProfileInfo/ProfileInfo';
 import ProfilePlayList from '../../components/profile/PlayList/ProfilePlayList';
 import ProfilePostList from '../../components/profile/PostList/ProfilePostList';
-import ProfileModal from '../../components/profile/ProfileModal';
+// import ProfileModal from '../../components/profile/ProfileModal';
 import styled from 'styled-components';
+import { readAccountInfo } from '../../apis/profile/accountInfoAPI';
+import { useQuery } from '@tanstack/react-query';
+import { useParams, useNavigate } from 'react-router-dom';
 
 const ContBox = styled.div`
   height: 100vh;
@@ -13,16 +16,28 @@ const ContBox = styled.div`
 `;
 
 export default function Profile() {
-  const [modal, setModal] = useState(false);
+  const [cnt, setCnt] = useState(0);
+  const navigate = useNavigate();
+  const { accountname } = useParams();
+  // const [modal, setModal] = useState(false);
+  const [profile, setProfile] = useState({});
+  const { data, error } = useQuery({
+    queryFn: () =>
+      readAccountInfo(accountname).then((res) => {
+        setProfile(res.profile);
+        console.log(res);
+        return res;
+      }),
+    queryKey: ['accountInfo']
+  });
+
   return (
     <ContBox>
       <NavBar />
-      {/* <ProfileNav modal={modal} setModal={setModal} /> */}
-      <ProfileInfo />
-      <ProfilePlayList />
-      <ProfilePostList />
+      <ProfileInfo profile={profile} />
+      <ProfilePlayList profile={profile} />
+      <ProfilePostList profile={profile} />
       <TabMenu />
-      {modal ? <ProfileModal /> : ''}
     </ContBox>
   );
 }

--- a/src/router/Router.jsx
+++ b/src/router/Router.jsx
@@ -22,9 +22,9 @@ export default function AppRouter() {
       <Route path='/home/search' element={<SearchPage />} />
       <Route path='/chat' element={<Chat />} />
       <Route path='/write' element={<Write />} />
-      <Route path='/profile' element={<Profile />} />
-      <Route path='/followers' element={<Followers />} />
-      <Route path='/followings' element={<Followings />} />
+      <Route path='/profile/:accountname' element={<Profile />} />
+      <Route path='/profile/:accountname/follower' element={<Followers />} />
+      <Route path='/profile/:accountname/following' element={<Followings />} />
       <Route path='/signup' element={<SignUpPage />} />
       <Route path='/profilesetting' element={<ProfileSettingPage />} />
       <Route path='/signin' element={<SignInPage />} />


### PR DESCRIPTION
## 구현 사항
- 계정별 프로필 정보 데이터 뿌려주기
- 유저 정보 비교로 수정 버튼 / 팔로우 버튼 조건부 렌더링
- 초기 팔로우 상태로 팔로우 / 언팔로우 버튼 조건부 렌더링
- 계정 팔로우 / 언팔로우 API 기능 구현
- 나의 팔로우/팔로잉 수 표현하기
- 팔로잉 목록 데이터 뿌려주기
- 팔로워 목록 데이터 뿌려주기
- 팔로잉 / 팔로워 각 목록 내 팔로우 / 언팔로우 API 기능 구현
- 프로필 / 팔로우 관련 페이지 route 수정
- 프로필 / 팔로우 관련 NavBar 경로 조건 수정

