### PR TITLE
fix(프로필) : 프로필 페이지 버그 수정

### DIFF
--- a/src/components/profile/ProfileInfo/ProfileInfo.jsx
+++ b/src/components/profile/ProfileInfo/ProfileInfo.jsx
@@ -28,7 +28,7 @@ export default function ProfileInfo() {
         setFollowingCnt(res.profile.followingCount);
         return res;
       }),
-    queryKey: [user.accountname, profile]
+    queryKey: [user.accountname, accountname]
   });
 
   const handleFollowClick = (url) => {
@@ -67,7 +67,9 @@ export default function ProfileInfo() {
           <S.FollowText>followers</S.FollowText>
         </S.ColBox>
         <S.ImgBox>
-          <img src={String(profile.image).includes('Ellipse.png') ? basicProfile : profile.image} alt=''></img>
+          <img
+            src={!profile.image || String(profile.image).includes('Ellipse.png') ? basicProfile : profile.image}
+            alt=''></img>
         </S.ImgBox>
         <S.ColBox>
           <S.FollowNum onClick={() => handleFollowClick('/following')} $fontColor='#767676'>

--- a/src/components/profile/ProfileInfo/ProfileInfo.styled.js
+++ b/src/components/profile/ProfileInfo/ProfileInfo.styled.js
@@ -72,6 +72,9 @@ export const IntroContent = styled.p`
   color: #767676;
   font-size: 14px;
   margin-top: 16px;
+  word-wrap: break-word;
+  text-align: center;
+  width: 60vw;
 `;
 
 export const RowButtonBox = styled(RowBox)`


### PR DESCRIPTION
- 프로필 소개 메세지 길이가 아주아주 길 경우를 대비해 메세지 구역 크기를 추가해 주었다!
- 프로필 useQuery 의존값을 바꿔주어 탭메뉴로 프로필에 접근했을 때 데이터를 잘 불러오도록 수정했다!